### PR TITLE
Todoist export / page scraper

### DIFF
--- a/src/hudl/ops/pagerduty/README.md
+++ b/src/hudl/ops/pagerduty/README.md
@@ -12,5 +12,5 @@ Run `--helpMe`; it'll print helpful stuff.
 ```
 
 ## Ideas
-[x] Make it schedule entire week for user via 5 requests.
-[ ] Hard-code map of Engineer:PagerDuty ID so --user can be argument like 'Derek'
+- [x] Make it schedule entire week for user via 5 requests.
+- [ ] Hard-code map of Engineer:PagerDuty ID so --user can be argument like 'Derek'

--- a/src/hudl/ops/pagerduty/create-override.sh
+++ b/src/hudl/ops/pagerduty/create-override.sh
@@ -1,13 +1,13 @@
+#!/bin/sh
 # PN59INH => Connect High-Priority schedule
 curl 'https://hudl.pagerduty.com/api/v1/schedules/PN59INH/overrides/' \
   -X POST \
+  -H 'cookie: xxx-xxx-xxx' \
   -H 'sec-fetch-mode: cors' \
   -H 'origin: https://hudl.pagerduty.com' \
   -H 'accept-encoding: gzip, deflate, br' \
-  # -H 'x-csrf-token: xxx-xxx-xxx' \
   -H 'accept-language: en-US,en;q=0.9' \
   -H 'x-requested-with: XMLHttpRequest' \
-  -H 'cookie: xxx-xxx-xxx' \
   -H 'x-pagerduty-api-local: 1' \
   -H 'content-type: application/json' \
   -H 'accept: application/vnd.pagerduty+json;version=2' \

--- a/src/personal/todoist/todoist-current-view-export.js
+++ b/src/personal/todoist/todoist-current-view-export.js
@@ -1,8 +1,28 @@
 // Run from JavaScript Console.
-const tasks = document.getElementsByClassName('task_item_content_text');
-const output = [];
-for (let task of tasks) {
-  output.push(task.textContent);
+function main() {
+  const tasksText = Array
+    .from(
+      document.getElementsByClassName('task_item_content_text'),
+      task => (task.textContent))
+    .join('\n');
+
+  // Need permission to write directly to clipboard (?)
+  // const success = await navigator.clipboard.writeText(tasksText);
+
+  window.alert(tasksText);
+
+  // Select alert text, copy to clipboard.
+  // Won't work in Firefox, may work in Chrome.
+  const range = document.createRange();
+  range.selectNode(document.querySelector('.text_holder'));
+
+  window.getSelection().removeAllRanges();
+  window.getSelection().addRange(range);
+  document.execCommand("copy");
+  window.getSelection().removeAllRanges();
+
+  // Copy via console.
+  copy(tasksText);
 }
 
-alert(output.join("\n"));
+main();

--- a/src/personal/todoist/todoist-current-view-export.js
+++ b/src/personal/todoist/todoist-current-view-export.js
@@ -1,28 +1,25 @@
 // Run from JavaScript Console.
-function main() {
-  const tasksText = Array
-    .from(
-      document.getElementsByClassName('task_item_content_text'),
-      task => (task.textContent))
-    .join('\n');
+var tasksText = Array
+  .from(
+    document.getElementsByClassName('task_item_content_text'),
+    task => (task.textContent))
+  .join('\n');
 
-  // Need permission to write directly to clipboard (?)
-  // const success = await navigator.clipboard.writeText(tasksText);
+window.alert(tasksText);
 
-  window.alert(tasksText);
+// Need permission to write directly to clipboard (?)
+// const success = await navigator.clipboard.writeText(tasksText);
 
-  // Select alert text, copy to clipboard.
-  // Won't work in Firefox, may work in Chrome.
-  const range = document.createRange();
-  range.selectNode(document.querySelector('.text_holder'));
+// Select alert text, copy to clipboard.
+// Won't work in Firefox, may work in Chrome.
 
-  window.getSelection().removeAllRanges();
-  window.getSelection().addRange(range);
-  document.execCommand("copy");
-  window.getSelection().removeAllRanges();
+const range = document.createRange();
+range.selectNode(document.querySelector('.text_holder'));
 
-  // Copy via console.
-  copy(tasksText);
-}
+window.getSelection().removeAllRanges();
+window.getSelection().addRange(range);
+document.execCommand("copy");
+window.getSelection().removeAllRanges();
 
-main();
+// Copy via console.
+copy(tasksText);

--- a/src/personal/todoist/todoist-current-view-export.js
+++ b/src/personal/todoist/todoist-current-view-export.js
@@ -1,0 +1,8 @@
+// Run from JavaScript Console.
+const tasks = document.getElementsByClassName('task_item_content_text');
+const output = [];
+for (let task of tasks) {
+  output.push(task.textContent);
+}
+
+alert(output.join("\n"));

--- a/src/personal/todoist/todoist-current-view-export.js
+++ b/src/personal/todoist/todoist-current-view-export.js
@@ -7,19 +7,5 @@ var tasksText = Array
 
 window.alert(tasksText);
 
-// Need permission to write directly to clipboard (?)
-// const success = await navigator.clipboard.writeText(tasksText);
-
-// Select alert text, copy to clipboard.
-// Won't work in Firefox, may work in Chrome.
-
-const range = document.createRange();
-range.selectNode(document.querySelector('.text_holder'));
-
-window.getSelection().removeAllRanges();
-window.getSelection().addRange(range);
-document.execCommand("copy");
-window.getSelection().removeAllRanges();
-
 // Copy via console.
 copy(tasksText);


### PR DESCRIPTION
Iterate through all tasks in the current Todoist view, alert text from each and copy to clipboard.

Useful for planning day via Todoist, then copying tasks elsewhere.